### PR TITLE
Add missing hooks

### DIFF
--- a/patch.h
+++ b/patch.h
@@ -1,0 +1,84 @@
+#ifndef PATCH_H 
+#define PATCH_H 
+
+#include <windows.h>
+
+static inline PROC patch_call(char *src, char *dst)
+{
+    DWORD op = PAGE_EXECUTE_READ;
+    VirtualProtect(src, 5, PAGE_EXECUTE_READWRITE, &op);
+    src[0] = 0xE8;
+    DWORD org = *((DWORD *)(&src[1]));
+    *((DWORD *)(&src[1])) = dst - src - 5;
+    VirtualProtect(src, 5, op, &op);
+    return (PROC)(src + 5 + org);
+}
+
+static inline void patch_call_nop(char *src, char *dst)
+{
+    DWORD op = PAGE_EXECUTE_READ;
+    VirtualProtect(src, 6, PAGE_EXECUTE_READWRITE, &op);
+    src[0] = 0xE8;
+    *((DWORD *)(&src[1])) = dst - src - 5;
+    src[5] = 0x90;
+    VirtualProtect(src, 6, op, &op);
+}
+
+static inline void patch_ljmp(char *src, char *dst)
+{
+    DWORD op = PAGE_EXECUTE_READ;
+    VirtualProtect(src, 5, PAGE_EXECUTE_READWRITE, &op);
+    src[0] = 0xE9;
+    *((DWORD *)(&src[1])) = dst - src - 5;
+    VirtualProtect(src, 5, op, &op);
+}
+
+static inline void patch_clear(char *start, char value, char *end)
+{
+    DWORD op = PAGE_EXECUTE_READ;
+    VirtualProtect(start, end - start, PAGE_EXECUTE_READWRITE, &op);
+    memset(start, value, end - start);
+    VirtualProtect(start, end - start, op, &op);
+}
+
+static inline DWORD patch_setdword(DWORD *dst, DWORD value)
+{
+    DWORD op = PAGE_EXECUTE_READ;
+    VirtualProtect(dst, sizeof(DWORD), PAGE_EXECUTE_READWRITE, &op);
+    DWORD org = *dst;
+    *dst = value; 
+    VirtualProtect(dst, sizeof(DWORD), op, &op);
+    return org;
+}
+
+static inline WORD patch_setword(WORD *dst, WORD value)
+{
+    DWORD op = PAGE_EXECUTE_READ;
+    VirtualProtect(dst, sizeof(WORD), PAGE_EXECUTE_READWRITE, &op);
+    WORD org = *dst;
+    *dst = value; 
+    VirtualProtect(dst, sizeof(WORD), op, &op);
+    return org;
+}
+
+static inline BYTE patch_setbyte(BYTE *dst, BYTE value)
+{
+    DWORD op = PAGE_EXECUTE_READ;
+    VirtualProtect(dst, sizeof(BYTE), PAGE_EXECUTE_READWRITE, &op);
+    BYTE org = *dst;
+    *dst = value; 
+    VirtualProtect(dst, sizeof(BYTE), op, &op);
+    return org;
+}
+
+static inline void patch_setbytes(char *dst, char *buf, size_t size)
+{
+    DWORD op = PAGE_EXECUTE_READ;
+    VirtualProtect(dst, size, PAGE_EXECUTE_READWRITE, &op);
+    memcpy(dst, buf, size);
+    VirtualProtect(dst, size, op, &op);
+}
+
+#define PATCH_SET(a,b) patch_setbytes(a,b,sizeof(b)-1)
+
+#endif

--- a/wgmus.c
+++ b/wgmus.c
@@ -809,9 +809,14 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
 	if (fdwReason == DLL_PROCESS_ATTACH)
 	{
-		patch_call_nop((void*)0x004E4708, (void*)fake_ExitProcess);
-		patch_call_nop((void*)0x004E71A0, (void*)fake_ExitProcess);
-		patch_call_nop((void*)0x004EADF2, (void*)fake_ExitProcess);
+		/* Make sure we are in Total Annihilation process before patching */
+		HMODULE game_exe = GetModuleHandleA(NULL);
+		if (game_exe && memcmp((char*)game_exe + 0x00010000, "\x14\x68\x78\x1B\x50\x00\x8D\x4C\x24\x1B", 10) == 0)
+		{
+			patch_call_nop((void*)0x004E4708, (void*)fake_ExitProcess);
+			patch_call_nop((void*)0x004E71A0, (void*)fake_ExitProcess);
+			patch_call_nop((void*)0x004EADF2, (void*)fake_ExitProcess);
+		}
 
 		fh = fopen("wgmus.log", "w"); /* Renamed to .log*/
 

--- a/wgmus.c
+++ b/wgmus.c
@@ -23,6 +23,7 @@
 #include <ctype.h>
 #include <dirent.h>
 #include <string.h>
+#include "patch.h"
 
 
 /* AUDIO LIBRARY INCLUDES START */
@@ -808,6 +809,10 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
 	if (fdwReason == DLL_PROCESS_ATTACH)
 	{
+		patch_call_nop((void*)0x004E4708, (void*)fake_ExitProcess);
+		patch_call_nop((void*)0x004E71A0, (void*)fake_ExitProcess);
+		patch_call_nop((void*)0x004EADF2, (void*)fake_ExitProcess);
+
 		fh = fopen("wgmus.log", "w"); /* Renamed to .log*/
 
 		GetModuleFileName(hinstDLL, musdll_path, sizeof musdll_path);


### PR DESCRIPTION
hook ExitProcess calls and forward them to fake_ExitProcess to make sure BASS_*Free functions are being called on exit

Currently nothing is calling fake_ExitProcess, this pull request is fixing the bug